### PR TITLE
Refactoring/pam 4324

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - RepoBasedSolution
+      - refactoring/PAM-4324
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/naiserator-dev.json
+++ b/naiserator-dev.json
@@ -1,3 +1,5 @@
 {
-  "ingress": ["https://pam-ad-statistics-demo.nais.oera-q.local"]
+  "ingress": [
+    "https://pam-ad-statistics-demo.nais.oera-q.local"
+  ]
 }

--- a/naiserator-prod.json
+++ b/naiserator-prod.json
@@ -1,3 +1,5 @@
 {
-  "ingress": ["https://pam-ad-statistics-demo.nais.oera.no"]
+  "ingress": [
+    "https://pam-ad-statistics-demo.nais.oera.no"
+  ]
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/AdAnalyticsController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/AdAnalyticsController.kt
@@ -1,12 +1,12 @@
 package no.nav.arbeidsplassen.analytics.ad
 
 import no.nav.arbeidsplassen.analytics.ad.dto.AdDto
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 
 @RestController
 @RequestMapping("ad")
@@ -21,7 +21,6 @@ class AdAnalyticsController(
         return adAnalyticsRepository.getDtoFromUUID(UUID)
     }
 
-
     @GetMapping("/internal/isAlive")
     fun isAlive(): ResponseEntity<String> =
         ResponseEntity("OK", HttpStatus.OK)
@@ -29,5 +28,4 @@ class AdAnalyticsController(
     @GetMapping("/internal/isReady")
     fun isReady(): ResponseEntity<String> =
         ResponseEntity("OK", HttpStatus.OK)
-
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/DimensionEntity.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/DimensionEntity.kt
@@ -17,26 +17,31 @@ import com.google.auth.http.HttpCredentialsAdapter
 import com.google.auth.oauth2.GoogleCredentials
 import no.nav.arbeidsplassen.analytics.ad.dto.AdDto
 
-abstract class DimensionEntity(startTrackingDate: String, endTrackingDate: String) {
+abstract class DimensionEntity() {
     private var analyticsReporting = initializeAnalyticsReporting()
     var rows = listOf<ReportRow>()
     private var nextPageToken: String? = ""
     abstract val metricExpressions: List<String>
     abstract val dimensionNames: List<String>
-    private val startDate = startTrackingDate
-    private val endDate = endTrackingDate
+    private var startDate = "1DaysAgo"
+    private var endDate = "today"
 
     abstract fun toAdDto(row: ReportRow): AdDto
+
+    fun setDateRange(startDate: String, endDate: String) {
+        this.startDate = startDate
+        this.endDate = endDate
+    }
 
     fun nextPage(): Boolean {
         return nextPageToken?.let {
             val reportsResponse =
                 analyticsReporting.getReportsResponse(
-                    metricExpressions,
-                    dimensionNames,
-                    nextPageToken,
-                    startDate,
-                    endDate
+                    metricExpressions = metricExpressions,
+                    dimensionNames = dimensionNames,
+                    pageToken = nextPageToken,
+                    startDate = startDate,
+                    endDate = endDate
                 )
 
             rows = reportsResponse.getReport().data.rows
@@ -102,10 +107,7 @@ abstract class DimensionEntity(startTrackingDate: String, endTrackingDate: Strin
     }
 }
 
-class ReferralEntity(
-    startTrackingDate: String,
-    endTrackingDate: String
-) : DimensionEntity(startTrackingDate, endTrackingDate) {
+class ReferralEntity : DimensionEntity() {
     override val metricExpressions = listOf("ga:pageviews", "ga:avgTimeOnPage")
     override val dimensionNames = listOf("ga:pagePath", "ga:fullReferrer")
 
@@ -119,10 +121,7 @@ class ReferralEntity(
     }
 }
 
-class DateEntity(
-    startTrackingDate: String,
-    endTrackingDate: String
-) : DimensionEntity(startTrackingDate, endTrackingDate) {
+class DateEntity : DimensionEntity() {
     override val metricExpressions = listOf("ga:pageviews")
     override val dimensionNames = listOf("ga:pagePath", "ga:date")
 

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/DimensionEntity.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/DimensionEntity.kt
@@ -1,0 +1,121 @@
+package no.nav.arbeidsplassen.analytics.ad
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.http.HttpRequestInitializer
+import com.google.api.client.http.HttpTransport
+import com.google.api.client.json.gson.GsonFactory
+import com.google.api.services.analyticsreporting.v4.AnalyticsReporting
+import com.google.api.services.analyticsreporting.v4.AnalyticsReportingScopes
+import com.google.api.services.analyticsreporting.v4.model.DateRange
+import com.google.api.services.analyticsreporting.v4.model.Dimension
+import com.google.api.services.analyticsreporting.v4.model.GetReportsRequest
+import com.google.api.services.analyticsreporting.v4.model.GetReportsResponse
+import com.google.api.services.analyticsreporting.v4.model.Metric
+import com.google.api.services.analyticsreporting.v4.model.ReportRequest
+import com.google.api.services.analyticsreporting.v4.model.ReportRow
+import com.google.auth.http.HttpCredentialsAdapter
+import com.google.auth.oauth2.GoogleCredentials
+import no.nav.arbeidsplassen.analytics.ad.dto.AdDto
+
+abstract class DimensionEntity {
+    private var analyticsReporting = initializeAnalyticsReporting()
+    var rows = listOf<ReportRow>()
+    private var nextPageToken: String? = ""
+    abstract val metricExpressions: List<String>
+    abstract val dimensionNames: List<String>
+
+    abstract fun toAdDto(row: ReportRow): AdDto
+
+    fun nextPage(): Boolean {
+        return nextPageToken?.let {
+            val reportsResponse =
+                analyticsReporting.getReportsResponse(metricExpressions, dimensionNames, nextPageToken)
+            rows = reportsResponse.getReport().data.rows
+            nextPageToken = reportsResponse.getReport().nextPageToken
+            true
+        } ?: false
+    }
+
+    private fun AnalyticsReporting.getReportsResponse(
+        metricExpressions: List<String>,
+        dimensionNames: List<String>,
+        pageToken: String? = null
+    ): GetReportsResponse {
+
+        val dateRange = DateRange().apply {
+            startDate = "1DaysAgo"
+            endDate = "today"
+        }
+        val metrics: List<Metric> = metricExpressions.map { Metric().setExpression(it) }
+        val dimensions: List<Dimension> = dimensionNames.map { Dimension().setName(it) }
+
+        val request = ReportRequest()
+            .setViewId(VIEW_ID)
+            .setDateRanges(listOf(dateRange))
+            .setMetrics(metrics)
+            .setDimensions(dimensions)
+            .setFiltersExpression("ga:pagePath=~^/stillinger")
+            //burde være variabel
+            .setPageSize(10000)
+
+        pageToken?.let {
+            request.pageToken = it
+        }
+
+        return reports().batchGet(GetReportsRequest().setReportRequests(listOf(request))).execute()
+    }
+
+    //this is implying we only send one request
+    private fun GetReportsResponse.getReport() = reports.first()
+
+    private fun initializeAnalyticsReporting(): AnalyticsReporting {
+        val httpTransport: HttpTransport = GoogleNetHttpTransport.newTrustedTransport()
+
+        val credential = GoogleCredentials
+            .fromStream(GoogleAnalyticsService::class.java.getResourceAsStream("/credentials.json"))
+            .createScoped(listOf(AnalyticsReportingScopes.ANALYTICS_READONLY))
+
+        val requestInitializer: HttpRequestInitializer = HttpCredentialsAdapter(credential)
+
+        return AnalyticsReporting.Builder(
+            httpTransport,
+            JSON_FACTORY, requestInitializer
+        )
+            .setApplicationName(APPLICATION_NAME).build()
+    }
+
+    companion object {
+        private const val VIEW_ID = "177785619"
+        private const val APPLICATION_NAME = "Analytics Reporting Demo"
+        private val JSON_FACTORY = GsonFactory.getDefaultInstance()
+    }
+}
+
+class ReferralEntity : DimensionEntity() {
+    override val metricExpressions = listOf("ga:pageviews", "ga:avgTimeOnPage")
+    override val dimensionNames = listOf("ga:pagePath", "ga:fullReferrer")
+
+    override fun toAdDto(row: ReportRow): AdDto {
+        return AdDto(
+            pageViews = row.getMetric().first().toInt(),
+            averageTimeOnPage = listOf(row.getMetric().last().toDouble()),
+            referrals = listOf(row.dimensions.last()),
+            viewsPerReferral = listOf(row.getMetric().first().toInt())
+        )
+    }
+}
+
+class DateEntity : DimensionEntity() {
+    override val metricExpressions = listOf("ga:pageviews")
+    override val dimensionNames = listOf("ga:pagePath", "ga:date")
+
+    override fun toAdDto(row: ReportRow): AdDto {
+        return AdDto(
+            dates = listOf(row.dimensions.last()),
+            viewsPerDate = listOf(row.getMetric().first().toInt())
+        )
+    }
+}
+
+private fun ReportRow.getMetric() = metrics.first().getValues()
+

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/GoogleAnalyticsService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/GoogleAnalyticsService.kt
@@ -37,7 +37,7 @@ class GoogleAnalyticsService(
         val httpTransport: HttpTransport = GoogleNetHttpTransport.newTrustedTransport()
 
         val credential = GoogleCredentials
-            .fromStream(googleApiCredentials.replace("\\\\n", "\\n").byteInputStream())
+            .fromStream(googleApiCredentials.replace("\\\\n", "").byteInputStream())
             .createScoped(listOf(AnalyticsReportingScopes.ANALYTICS_READONLY))
 
         val requestInitializer: HttpRequestInitializer = HttpCredentialsAdapter(credential)

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/GoogleAnalyticsService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/GoogleAnalyticsService.kt
@@ -12,7 +12,7 @@ class GoogleAnalyticsService(
 ) {
 
     private fun reportsResponseToStatisticsRepo(
-        dimensionEntities: List<DimensionEntity>
+        vararg dimensionEntities: DimensionEntity
     ): MutableMap<String, AdDto> {
         val adDtoMap = mutableMapOf<String, AdDto>()
         //kanskje litt mange foreaches
@@ -42,7 +42,10 @@ class GoogleAnalyticsService(
 
     @PostConstruct
     private fun initializeRepo() {
-        val UUIDToDtoMap = reportsResponseToStatisticsRepo(listOf(ReferralEntity(), DateEntity()))
+        val UUIDToDtoMap = reportsResponseToStatisticsRepo(
+            ReferralEntity(startTrackingDate = "1DaysAgo", endTrackingDate = "today"),
+            DateEntity(startTrackingDate = "1DaysAgo", endTrackingDate = "today")
+        )
 
         adAnalyticsRepository.updateUUIDToDtoMap(UUIDToDtoMap)
     }
@@ -53,7 +56,10 @@ class GoogleAnalyticsService(
     //kanskje fixeddelay/fixedrate istedet for cron
     @Scheduled(cron = "0 0 * * * *", zone = "Europe/Oslo")
     private fun scheduledRepoUpdate() {
-        val UUIDToDtoMap = reportsResponseToStatisticsRepo(listOf(ReferralEntity(), DateEntity()))
+        val UUIDToDtoMap = reportsResponseToStatisticsRepo(
+            ReferralEntity(startTrackingDate = "1DaysAgo", endTrackingDate = "today"),
+            DateEntity(startTrackingDate = "1DaysAgo", endTrackingDate = "today")
+        )
 
         adAnalyticsRepository.updateUUIDToDtoMap(UUIDToDtoMap)
     }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/GoogleAnalyticsService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/GoogleAnalyticsService.kt
@@ -12,11 +12,14 @@ class GoogleAnalyticsService(
 ) {
 
     private fun reportsResponseToStatisticsRepo(
+        startDate: String,
+        endDate: String,
         vararg dimensionEntities: DimensionEntity
     ): MutableMap<String, AdDto> {
         val adDtoMap = mutableMapOf<String, AdDto>()
         //kanskje litt mange foreaches
         dimensionEntities.forEach { dimensionEntity ->
+            dimensionEntity.setDateRange(startDate, endDate)
             while (dimensionEntity.nextPage()) {
                 dimensionEntity.rows.forEach { row ->
                     val adPath = row.dimensions.first().split("/").last()
@@ -43,8 +46,10 @@ class GoogleAnalyticsService(
     @PostConstruct
     private fun initializeRepo() {
         val UUIDToDtoMap = reportsResponseToStatisticsRepo(
-            ReferralEntity(startTrackingDate = "1DaysAgo", endTrackingDate = "today"),
-            DateEntity(startTrackingDate = "1DaysAgo", endTrackingDate = "today")
+            "1DaysAgo",
+            "today",
+            ReferralEntity(),
+            DateEntity()
         )
 
         adAnalyticsRepository.updateUUIDToDtoMap(UUIDToDtoMap)
@@ -57,8 +62,10 @@ class GoogleAnalyticsService(
     @Scheduled(cron = "0 0 * * * *", zone = "Europe/Oslo")
     private fun scheduledRepoUpdate() {
         val UUIDToDtoMap = reportsResponseToStatisticsRepo(
-            ReferralEntity(startTrackingDate = "1DaysAgo", endTrackingDate = "today"),
-            DateEntity(startTrackingDate = "1DaysAgo", endTrackingDate = "today")
+            "1DaysAgo",
+            "today",
+            ReferralEntity(),
+            DateEntity()
         )
 
         adAnalyticsRepository.updateUUIDToDtoMap(UUIDToDtoMap)

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/GoogleAnalyticsService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/GoogleAnalyticsService.kt
@@ -1,24 +1,6 @@
 package no.nav.arbeidsplassen.analytics.ad
 
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-import com.google.api.client.http.HttpRequestInitializer
-import com.google.api.client.http.HttpTransport
-import com.google.api.client.json.gson.GsonFactory
-import com.google.api.services.analyticsreporting.v4.AnalyticsReporting
-import com.google.api.services.analyticsreporting.v4.AnalyticsReportingScopes
-import com.google.api.services.analyticsreporting.v4.model.DateRange
-import com.google.api.services.analyticsreporting.v4.model.Dimension
-import com.google.api.services.analyticsreporting.v4.model.GetReportsRequest
-import com.google.api.services.analyticsreporting.v4.model.GetReportsResponse
-import com.google.api.services.analyticsreporting.v4.model.Metric
-import com.google.api.services.analyticsreporting.v4.model.ReportRequest
-import com.google.auth.http.HttpCredentialsAdapter
-import com.google.auth.oauth2.GoogleCredentials
 import no.nav.arbeidsplassen.analytics.ad.dto.AdDto
-import no.nav.arbeidsplassen.analytics.ad.dto.DateEntity
-import no.nav.arbeidsplassen.analytics.ad.dto.DimensionEntity
-import no.nav.arbeidsplassen.analytics.ad.dto.ReferralEntity
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -26,83 +8,20 @@ import javax.annotation.PostConstruct
 
 @Service
 class GoogleAnalyticsService(
-    private val adAnalyticsRepository: AdAnalyticsRepository,
-    @Value("\${GOOGLE_API_CREDENTIALS}")
-    private val googleApiCredentials: String
+    private val adAnalyticsRepository: AdAnalyticsRepository
 ) {
 
-    private var analyticsReporting = initializeAnalyticsReporting()
-
-    private fun initializeAnalyticsReporting(): AnalyticsReporting {
-        val httpTransport: HttpTransport = GoogleNetHttpTransport.newTrustedTransport()
-
-        val credential = GoogleCredentials
-            .fromStream(googleApiCredentials.replace("\\\\n", "").byteInputStream())
-            .createScoped(listOf(AnalyticsReportingScopes.ANALYTICS_READONLY))
-
-        val requestInitializer: HttpRequestInitializer = HttpCredentialsAdapter(credential)
-
-        return AnalyticsReporting.Builder(
-            httpTransport,
-            JSON_FACTORY, requestInitializer
-        )
-            .setApplicationName(APPLICATION_NAME).build()
-    }
-
-    private fun AnalyticsReporting.getReportsResponse(
-        metricExpressions: List<String>,
-        dimensionNames: List<String>,
-        pageToken: String? = null
-    ): GetReportsResponse {
-
-        val dateRange = DateRange().apply {
-            startDate = "1DaysAgo"
-            endDate = "today"
-        }
-        val metrics: List<Metric> = metricExpressions.map { Metric().setExpression(it) }
-        val dimensions: List<Dimension> = dimensionNames.map { Dimension().setName(it) }
-
-        val request = ReportRequest()
-            .setViewId(VIEW_ID)
-            .setDateRanges(listOf(dateRange))
-            .setMetrics(metrics)
-            .setDimensions(dimensions)
-            .setFiltersExpression("ga:pagePath=~^/stillinger")
-            //burde være variabel
-            .setPageSize(10000)
-
-        pageToken?.let {
-            request.pageToken = it
-        }
-
-
-        return reports().batchGet(GetReportsRequest().setReportRequests(listOf(request))).execute()
-    }
-
     private fun reportsResponseToStatisticsRepo(
-        dimensionEntity: DimensionEntity,
-        adDtoMap: MutableMap<String, AdDto> = mutableMapOf<String, AdDto>(),
-        metricExpressions: List<String>,
-        dimensionNames: List<String>
+        dimensionEntities: List<DimensionEntity>
     ): MutableMap<String, AdDto> {
-        var isNextToken = true
-        while (isNextToken) {
-            dimensionEntity.rows.forEach { row ->
-                val adPath = row.dimensions.first().split("/").last()
-                adDtoMap[adPath] = adDtoMap[adPath] mergeWith dimensionEntity.toAdDto(row)
-            }
-
-            val nextToken = dimensionEntity.nextPageToken
-            if (nextToken == null) {
-                //kunne hatt return her
-                isNextToken = false
-            } else {
-                val newReportsResponse = analyticsReporting.getReportsResponse(
-                    metricExpressions = metricExpressions,
-                    dimensionNames = dimensionNames,
-                    pageToken = nextToken
-                )
-                dimensionEntity.setGetReportsResponse(newReportsResponse)
+        val adDtoMap = mutableMapOf<String, AdDto>()
+        //kanskje litt mange foreaches
+        dimensionEntities.forEach { dimensionEntity ->
+            while (dimensionEntity.nextPage()) {
+                dimensionEntity.rows.forEach { row ->
+                    val adPath = row.dimensions.first().split("/").last()
+                    adDtoMap[adPath] = adDtoMap[adPath] mergeWith dimensionEntity.toAdDto(row)
+                }
             }
         }
         return adDtoMap
@@ -123,28 +42,7 @@ class GoogleAnalyticsService(
 
     @PostConstruct
     private fun initializeRepo() {
-        val referralReportsResponse = analyticsReporting.getReportsResponse(
-            metricExpressions = METRIC_EXPRESSIONS1,
-            dimensionNames = DIMENSION_NAMES1
-        )
-
-        val dateReportsResponse = analyticsReporting.getReportsResponse(
-            metricExpressions = METRIC_EXPRESSIONS2,
-            dimensionNames = DIMENSION_NAMES2
-        )
-
-        val halfwayMap = reportsResponseToStatisticsRepo(
-            dimensionEntity = ReferralEntity(referralReportsResponse),
-            metricExpressions = METRIC_EXPRESSIONS1,
-            dimensionNames = DIMENSION_NAMES1
-        )
-
-        val UUIDToDtoMap = reportsResponseToStatisticsRepo(
-            dimensionEntity = DateEntity(dateReportsResponse),
-            adDtoMap = halfwayMap,
-            metricExpressions = METRIC_EXPRESSIONS2,
-            dimensionNames = DIMENSION_NAMES2
-        )
+        val UUIDToDtoMap = reportsResponseToStatisticsRepo(listOf(ReferralEntity(), DateEntity()))
 
         adAnalyticsRepository.updateUUIDToDtoMap(UUIDToDtoMap)
     }
@@ -155,41 +53,8 @@ class GoogleAnalyticsService(
     //kanskje fixeddelay/fixedrate istedet for cron
     @Scheduled(cron = "0 0 * * * *", zone = "Europe/Oslo")
     private fun scheduledRepoUpdate() {
-        val referralReportsResponse = analyticsReporting.getReportsResponse(
-            metricExpressions = METRIC_EXPRESSIONS1,
-            dimensionNames = DIMENSION_NAMES1
-        )
+        val UUIDToDtoMap = reportsResponseToStatisticsRepo(listOf(ReferralEntity(), DateEntity()))
 
-        val dateReportsResponse = analyticsReporting.getReportsResponse(
-            metricExpressions = METRIC_EXPRESSIONS2,
-            dimensionNames = DIMENSION_NAMES2
-        )
-
-        val halfwayMap = reportsResponseToStatisticsRepo(
-            dimensionEntity = ReferralEntity(referralReportsResponse),
-            metricExpressions = METRIC_EXPRESSIONS1,
-            dimensionNames = DIMENSION_NAMES1
-        )
-
-        val UUIDToDtoMap = reportsResponseToStatisticsRepo(
-            dimensionEntity = DateEntity(dateReportsResponse),
-            adDtoMap = halfwayMap,
-            metricExpressions = METRIC_EXPRESSIONS2,
-            dimensionNames = DIMENSION_NAMES2
-        )
         adAnalyticsRepository.updateUUIDToDtoMap(UUIDToDtoMap)
-    }
-
-    companion object {
-        private const val VIEW_ID = "177785619"
-        private const val APPLICATION_NAME = "Analytics Reporting Demo"
-        private val JSON_FACTORY = GsonFactory.getDefaultInstance()
-
-        //metrics and dimension
-        private val METRIC_EXPRESSIONS1 = listOf("ga:pageviews", "ga:avgTimeOnPage")
-        private val DIMENSION_NAMES1 = listOf("ga:pagePath", "ga:fullReferrer")
-
-        private val METRIC_EXPRESSIONS2 = listOf("ga:pageviews")
-        private val DIMENSION_NAMES2 = listOf("ga:pagePath", "ga:date")
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdDto.kt
@@ -1,8 +1,5 @@
 package no.nav.arbeidsplassen.analytics.ad.dto
 
-import com.google.api.services.analyticsreporting.v4.model.GetReportsResponse
-import com.google.api.services.analyticsreporting.v4.model.ReportRow
-
 data class AdDto(
     var pageViews: Int = 0,
     //leaving the actual calculation to frontend
@@ -16,50 +13,3 @@ data class AdDto(
     var device: Map<String, String>
      */
 )
-
-//kanskje ha annet sted
-abstract class DimensionEntity {
-    var rows: List<ReportRow>
-    var nextPageToken: String?
-
-    constructor(reportsResponse: GetReportsResponse) {
-        rows = reportsResponse.getReport().data.rows
-        nextPageToken = reportsResponse.getReport().nextPageToken
-    }
-
-    abstract fun toAdDto(row: ReportRow): AdDto
-
-    fun setGetReportsResponse(reportsResponse: GetReportsResponse) {
-        rows = reportsResponse.getReport().data.rows
-        nextPageToken = reportsResponse.getReport().nextPageToken
-    }
-}
-
-class ReferralEntity(reportsResponse: GetReportsResponse) : DimensionEntity(reportsResponse) {
-
-    //ikke sikker på return eller dto-variabel
-    override fun toAdDto(row: ReportRow): AdDto {
-        return AdDto(
-            pageViews = row.getMetric().first().toInt(),
-            averageTimeOnPage = listOf(row.getMetric().last().toDouble()),
-            referrals = listOf(row.dimensions.last()),
-            viewsPerReferral = listOf(row.getMetric().first().toInt())
-        )
-    }
-}
-
-class DateEntity(reportsResponse: GetReportsResponse) : DimensionEntity(reportsResponse) {
-
-    //ikke sikker på return eller dto-variabel
-    override fun toAdDto(row: ReportRow): AdDto {
-        return AdDto(
-            dates = listOf(row.dimensions.last()),
-            viewsPerDate = listOf(row.getMetric().first().toInt())
-        )
-    }
-}
-
-//this is implying we only send one request
-private fun GetReportsResponse.getReport() = reports.first()
-
-private fun ReportRow.getMetric() = metrics.first().getValues()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,8 +20,6 @@ spring:
   profiles:
     active: ${NAIS_CLUSTER_NAME:dev}
 
-GOOGLE_API_CREDENTIALS: ${GOOGLE_API_CREDENTIALS}
-
 server:
   error:
     whitelabel:


### PR DESCRIPTION
- La all google-api logikk i DimensionsEntity.kt (kanskje litt for mye i en klasse?)
- Hver entity har tilhørende metrikker og dimensions som skal trackes inni seg
- Kun 1 reportsResponseToStatisticsRepo kall per repo (istedet for per DimensionEntity) på bekostning av en ekstra foreach (litt mye med en foreach inni en while inni enda en foreach kanskje?)
- Daterange kan endres ved å endre parameterene i reportsResponseToStatisticsRepo