### PR TITLE
Refactoring/pam 4337 refaktorer backend

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/DimensionEntity.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/DimensionEntity.kt
@@ -40,10 +40,12 @@ abstract class DimensionEntity<T : StatisticsDto<T>>(
 
     fun googleAnalyticsReportsToStatisticsDtoMap(listOfGoogleAnalyticsReportsRows: List<ReportRow>): Map<String, T> {
         return listOfGoogleAnalyticsReportsRows.map { row ->
-            getKey(row).map { it to toStatisticsDto(row) }
+            getKey(row).map { key -> key to toStatisticsDto(row) }
         }.flatten()
             .groupBy({ dtoMapEntry -> dtoMapEntry.first }, { dtoMapEntry -> dtoMapEntry.second })
-            .mapValues { (_, values) -> values.reduce { acc, statisticsDto -> acc.mergeWith(statisticsDto) } }
+            .mapValues { (_, values) ->
+                values.reduce { acc, statisticsDto -> acc.mergeWith(statisticsDto) }
+            }
     }
 }
 

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/DimensionEntity.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/DimensionEntity.kt
@@ -26,16 +26,21 @@ abstract class DimensionEntity<T : StatisticsDto<T>>(private val googleAnalytics
 
     fun getGoogleAnalyticsReport(pageToken: String): GoogleAnalyticsReport {
         return googleAnalyticsQuery.getGoogleAnalyticsReport(
-            metricExpressions= metricExpressions,
-            dimensionNames= dimensionNames,
-            filterExpression= filterExpression,
-            pageToken= pageToken,
-            startDate= startDate,
-            endDate= endDate
+            metricExpressions = metricExpressions,
+            dimensionNames = dimensionNames,
+            filterExpression = filterExpression,
+            pageToken = pageToken,
+            startDate = startDate,
+            endDate = endDate
         )
     }
 
-
+    fun googleAnalyticsReportsToStatisticsDtoMap(listOfGoogleAnalyticsReportsRows: List<ReportRow>): Map<String, T> {
+        return listOfGoogleAnalyticsReportsRows.map { row ->
+            getKey(row).map { it to toStatisticsDto(row) }
+        }.flatten().groupBy({ it.first }, { it.second })
+            .mapValues { (_, values) -> values.reduce { acc, statisticsDto -> acc.mergeWith(statisticsDto) } }
+    }
 }
 
 class ReferralEntity(
@@ -128,7 +133,7 @@ class CandidateFilterEntity(
 
     private fun queryStringToKey(queryString: String): List<String> {
         val pathAndQueries = queryString.split("?")
-        return if(pathAndQueries.first() == "kandidater") {
+        return if (pathAndQueries.first() == "kandidater") {
             val queryNameAndValues = pathAndQueries.last().split("&").last().split("=")
             listOf(
                 nameAndValueToString(queryNameAndValues.first(), queryNameAndValues.last().split("_").last())

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/GoogleAnalyticsService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/GoogleAnalyticsService.kt
@@ -48,6 +48,7 @@ class GoogleAnalyticsService(
 
     @PostConstruct
     private fun initializeRepo() {
+
         val UUIDToAdDtoMap = dimensionEntitiesToStatisticsDtoMap(
             "1DaysAgo",
             "today",

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/StatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/StatisticsDto.kt
@@ -3,4 +3,5 @@ package no.nav.arbeidsplassen.analytics
 interface StatisticsDto<T : StatisticsDto<T>> {
 
     infix fun mergeWith(other: T): T
+
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/StatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/StatisticsDto.kt
@@ -3,5 +3,4 @@ package no.nav.arbeidsplassen.analytics
 interface StatisticsDto<T : StatisticsDto<T>> {
 
     infix fun mergeWith(other: T): T
-
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/StatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/StatisticsDto.kt
@@ -2,5 +2,5 @@ package no.nav.arbeidsplassen.analytics
 
 interface StatisticsDto<T : StatisticsDto<T>> {
 
-    infix fun mergeWith(other: T?): T
+    infix fun mergeWith(other: T): T
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/AdStatisticsController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/AdStatisticsController.kt
@@ -16,6 +16,6 @@ class AdStatisticsController(
     fun getAdStatisticsData(
         @RequestParam(value = "adID", required = true) UUID: String
     ): AdStatisticsDto? {
-        return adStatisticsRepository.getAdStatisticsDtoFromUUID(UUID)
+        return adStatisticsRepository.getAdStatisticsDto(UUID)
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/AdStatisticsRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/AdStatisticsRepository.kt
@@ -11,5 +11,5 @@ class AdStatisticsRepository {
         this.UUIDToAdStatisticsDtoMap = UUIDToStatisticsDtoMap
     }
 
-    fun getAdStatisticsDtoFromUUID(UUID: String) = UUIDToAdStatisticsDtoMap[UUID]
+    fun getAdStatisticsDto(UUID: String) = UUIDToAdStatisticsDtoMap[UUID]
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdStatisticsDto.kt
@@ -20,5 +20,4 @@ class AdStatisticsDto(
             dates = this.dates + other.dates,
             viewsPerDate = this.viewsPerDate + other.viewsPerDate
         )
-
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdStatisticsDto.kt
@@ -12,12 +12,12 @@ class AdStatisticsDto(
 ) : StatisticsDto<AdStatisticsDto> {
 
     override infix fun mergeWith(other: AdStatisticsDto) =
-            AdStatisticsDto(
-                pageViews = this.pageViews + other.pageViews,
-                averageTimeOnPage = this.averageTimeOnPage + other.averageTimeOnPage,
-                referrals = this.referrals + other.referrals,
-                viewsPerReferral = this.viewsPerReferral + other.viewsPerReferral,
-                dates = this.dates + other.dates,
-                viewsPerDate = this.viewsPerDate + other.viewsPerDate
-            )
+        AdStatisticsDto(
+            pageViews = this.pageViews + other.pageViews,
+            averageTimeOnPage = this.averageTimeOnPage + other.averageTimeOnPage,
+            referrals = this.referrals + other.referrals,
+            viewsPerReferral = this.viewsPerReferral + other.viewsPerReferral,
+            dates = this.dates + other.dates,
+            viewsPerDate = this.viewsPerDate + other.viewsPerDate
+        )
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdStatisticsDto.kt
@@ -20,4 +20,5 @@ class AdStatisticsDto(
             dates = this.dates + other.dates,
             viewsPerDate = this.viewsPerDate + other.viewsPerDate
         )
+
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/ad/dto/AdStatisticsDto.kt
@@ -10,16 +10,14 @@ class AdStatisticsDto(
     var dates: List<String> = listOf(),
     var viewsPerDate: List<Int> = listOf()
 ) : StatisticsDto<AdStatisticsDto> {
-    override infix fun mergeWith(other: AdStatisticsDto?): AdStatisticsDto {
-        return other?.let {
+
+    override infix fun mergeWith(other: AdStatisticsDto) =
             AdStatisticsDto(
-                pageViews = it.pageViews + this.pageViews,
-                averageTimeOnPage = it.averageTimeOnPage + this.averageTimeOnPage,
-                referrals = it.referrals + this.referrals,
-                viewsPerReferral = it.viewsPerReferral + this.viewsPerReferral,
-                dates = it.dates + this.dates,
-                viewsPerDate = it.viewsPerDate + this.viewsPerDate
+                pageViews = this.pageViews + other.pageViews,
+                averageTimeOnPage = this.averageTimeOnPage + other.averageTimeOnPage,
+                referrals = this.referrals + other.referrals,
+                viewsPerReferral = this.viewsPerReferral + other.viewsPerReferral,
+                dates = this.dates + other.dates,
+                viewsPerDate = this.viewsPerDate + other.viewsPerDate
             )
-        } ?: this
-    }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/CandidateStatisticsController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/CandidateStatisticsController.kt
@@ -15,6 +15,6 @@ class CandidateStatisticsController(
     fun getCandidateStatisticsData(
         @RequestParam(value = "candidateID", required = true) UUID: String
     ): CandidateStatisticsDto? {
-        return candidateStatisticsRepository.getCandidateStatisticsDtoFromUUID(UUID)
+        return candidateStatisticsRepository.getCandidateStatisticsDto(UUID)
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/CandidateStatisticsRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/CandidateStatisticsRepository.kt
@@ -11,7 +11,7 @@ class CandidateStatisticsRepository {
         this.UUIDToCandidateStatisticsDtoMap = UUIDToStatisticsDtoMap
     }
 
-    fun getCandidateStatisticsDtoFromUUID(UUID: String) = UUIDToCandidateStatisticsDtoMap[UUID]
+    fun getCandidateStatisticsDto(UUID: String) = UUIDToCandidateStatisticsDtoMap[UUID]
 
     //debugging purposes
     fun prettyPrint() {

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/dto/CandidateStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/dto/CandidateStatisticsDto.kt
@@ -9,4 +9,5 @@ class CandidateStatisticsDto(
         CandidateStatisticsDto(
             pageViews = this.pageViews + other.pageViews
         )
+
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/dto/CandidateStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/dto/CandidateStatisticsDto.kt
@@ -5,11 +5,8 @@ import no.nav.arbeidsplassen.analytics.StatisticsDto
 class CandidateStatisticsDto(
     var pageViews: Int = 0
 ) : StatisticsDto<CandidateStatisticsDto> {
-    override infix fun mergeWith(other: CandidateStatisticsDto?): CandidateStatisticsDto {
-        return other?.let {
+    override infix fun mergeWith(other: CandidateStatisticsDto) =
             CandidateStatisticsDto(
-                pageViews = it.pageViews + this.pageViews
+                pageViews = this.pageViews + other.pageViews
             )
-        } ?: this
-    }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/dto/CandidateStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/dto/CandidateStatisticsDto.kt
@@ -6,7 +6,7 @@ class CandidateStatisticsDto(
     var pageViews: Int = 0
 ) : StatisticsDto<CandidateStatisticsDto> {
     override infix fun mergeWith(other: CandidateStatisticsDto) =
-            CandidateStatisticsDto(
-                pageViews = this.pageViews + other.pageViews
-            )
+        CandidateStatisticsDto(
+            pageViews = this.pageViews + other.pageViews
+        )
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/dto/CandidateStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/candidate/dto/CandidateStatisticsDto.kt
@@ -9,5 +9,4 @@ class CandidateStatisticsDto(
         CandidateStatisticsDto(
             pageViews = this.pageViews + other.pageViews
         )
-
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/CandidateFilterStatisticsController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/CandidateFilterStatisticsController.kt
@@ -18,7 +18,7 @@ class CandidateFilterStatisticsController(
     ): StatisticsDto<*>? {
         return filterValue?.let { filterValue ->
             val UUID = "${filterName.toLowerCase()}=${filterValue}"
-            return candidateFilterStatisticsRepository.getCandidateFilterStatisticsDtoFromUUID(UUID)
-        } ?: candidateFilterStatisticsRepository.getCandidateFilterSummaryDtoFromFilterName(filterName)
+            return candidateFilterStatisticsRepository.getCandidateFilterStatisticsDto(UUID)
+        } ?: candidateFilterStatisticsRepository.getCandidateFilterSummaryDto(filterName)
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/CandidateFilterStatisticsController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/CandidateFilterStatisticsController.kt
@@ -17,7 +17,7 @@ class CandidateFilterStatisticsController(
         @RequestParam(value = "filterValue", required = false) filterValue: String?
     ): StatisticsDto<*>? {
         return filterValue?.let { filterValue ->
-            val UUID = "${filterName.toLowerCase()}=${filterValue.toLowerCase()}"
+            val UUID = "${filterName.toLowerCase()}=${filterValue}"
             return candidateFilterStatisticsRepository.getCandidateFilterStatisticsDtoFromUUID(UUID)
         } ?: candidateFilterStatisticsRepository.getCandidateFilterSummaryDtoFromFilterName(filterName)
     }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/CandidateFilterStatisticsRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/CandidateFilterStatisticsRepository.kt
@@ -15,9 +15,9 @@ class CandidateFilterStatisticsRepository {
         this.UUIDToCandidateFilterStatisticsDtoMap = UUIDToCandidateFilterStatisticsDtoMap
     }
 
-    fun getCandidateFilterStatisticsDtoFromUUID(UUID: String) = UUIDToCandidateFilterStatisticsDtoMap[UUID]
+    fun getCandidateFilterStatisticsDto(UUID: String) = UUIDToCandidateFilterStatisticsDtoMap[UUID]
 
-    fun getCandidateFilterSummaryDtoFromFilterName(filterName: String): StatisticsDto<CandidateFilterSummaryDto> {
+    fun getCandidateFilterSummaryDto(filterName: String): StatisticsDto<CandidateFilterSummaryDto> {
         val filterNameMap = UUIDToCandidateFilterStatisticsDtoMap.filterKeys { it.startsWith("${filterName}=") }
         var candidateFilterSummaryDto = CandidateFilterSummaryDto()
         filterNameMap.forEach { (k, v) ->

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/CandidateFilterStatisticsRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/CandidateFilterStatisticsRepository.kt
@@ -18,7 +18,7 @@ class CandidateFilterStatisticsRepository {
     fun getCandidateFilterStatisticsDtoFromUUID(UUID: String) = UUIDToCandidateFilterStatisticsDtoMap[UUID]
 
     fun getCandidateFilterSummaryDtoFromFilterName(filterName: String): StatisticsDto<CandidateFilterSummaryDto> {
-        val filterNameMap = UUIDToCandidateFilterStatisticsDtoMap.filterKeys { it.startsWith(filterName) }
+        val filterNameMap = UUIDToCandidateFilterStatisticsDtoMap.filterKeys { it.startsWith("${filterName}=") }
         var candidateFilterSummaryDto = CandidateFilterSummaryDto()
         filterNameMap.forEach { (k, v) ->
             candidateFilterSummaryDto = candidateFilterSummaryDto mergeWith toCandidateFilterSummaryDto(k, v)
@@ -34,5 +34,11 @@ class CandidateFilterStatisticsRepository {
             pageViews = listOf(dto.pageViews),
             filterValues = listOf(key.split("=").last())
         )
+    }
+
+    fun prettyprint() {
+        UUIDToCandidateFilterStatisticsDtoMap.forEach { (k, v) ->
+            println("$k = ${v.pageViews}")
+        }
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterStatisticsDto.kt
@@ -6,7 +6,7 @@ class CandidateFilterStatisticsDto(
     var pageViews: Int = 0
 ) : StatisticsDto<CandidateFilterStatisticsDto> {
     override infix fun mergeWith(other: CandidateFilterStatisticsDto) =
-            CandidateFilterStatisticsDto(
-                pageViews = this.pageViews + other.pageViews
-            )
+        CandidateFilterStatisticsDto(
+            pageViews = this.pageViews + other.pageViews
+        )
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterStatisticsDto.kt
@@ -5,11 +5,8 @@ import no.nav.arbeidsplassen.analytics.StatisticsDto
 class CandidateFilterStatisticsDto(
     var pageViews: Int = 0
 ) : StatisticsDto<CandidateFilterStatisticsDto> {
-    override infix fun mergeWith(other: CandidateFilterStatisticsDto?): CandidateFilterStatisticsDto {
-        return other?.let {
+    override infix fun mergeWith(other: CandidateFilterStatisticsDto) =
             CandidateFilterStatisticsDto(
-                pageViews = it.pageViews + this.pageViews
+                pageViews = this.pageViews + other.pageViews
             )
-        } ?: this
-    }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterStatisticsDto.kt
@@ -9,4 +9,5 @@ class CandidateFilterStatisticsDto(
         CandidateFilterStatisticsDto(
             pageViews = this.pageViews + other.pageViews
         )
+
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterStatisticsDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterStatisticsDto.kt
@@ -9,5 +9,4 @@ class CandidateFilterStatisticsDto(
         CandidateFilterStatisticsDto(
             pageViews = this.pageViews + other.pageViews
         )
-
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterSummaryDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterSummaryDto.kt
@@ -7,8 +7,8 @@ class CandidateFilterSummaryDto(
     var filterValues: List<String> = listOf()
 ) : StatisticsDto<CandidateFilterSummaryDto> {
     override infix fun mergeWith(other: CandidateFilterSummaryDto) =
-            CandidateFilterSummaryDto(
-                pageViews = this.pageViews + other.pageViews,
-                filterValues = this.filterValues + other.filterValues
-            )
+        CandidateFilterSummaryDto(
+            pageViews = this.pageViews + other.pageViews,
+            filterValues = this.filterValues + other.filterValues
+        )
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterSummaryDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterSummaryDto.kt
@@ -11,5 +11,4 @@ class CandidateFilterSummaryDto(
             pageViews = this.pageViews + other.pageViews,
             filterValues = this.filterValues + other.filterValues
         )
-
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterSummaryDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterSummaryDto.kt
@@ -6,12 +6,9 @@ class CandidateFilterSummaryDto(
     var pageViews: List<Int> = listOf(),
     var filterValues: List<String> = listOf()
 ) : StatisticsDto<CandidateFilterSummaryDto> {
-    override infix fun mergeWith(other: CandidateFilterSummaryDto?): CandidateFilterSummaryDto {
-        return other?.let {
+    override infix fun mergeWith(other: CandidateFilterSummaryDto) =
             CandidateFilterSummaryDto(
                 pageViews = this.pageViews + other.pageViews,
                 filterValues = this.filterValues + other.filterValues
             )
-        } ?: this
-    }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterSummaryDto.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/analytics/filter/dto/CandidateFilterSummaryDto.kt
@@ -11,4 +11,5 @@ class CandidateFilterSummaryDto(
             pageViews = this.pageViews + other.pageViews,
             filterValues = this.filterValues + other.filterValues
         )
+
 }


### PR DESCRIPTION
- Condense the return object from getReportsResponse to an object GoogleAnalyticsReport
- Move nextPageToken outside of dimensionEntities
- Do all the "page-turning"-logic inside dimensionEntitiesToStatisticsDtoMap
- Try to clean up dimensionEntitiesToStatisticsDtoMap
- Don't use mutable maps
- Rename methods, functions and variables
- mergeWith will not need to check for nullability any more